### PR TITLE
Fix typo in variable

### DIFF
--- a/content/server/prosody.md
+++ b/content/server/prosody.md
@@ -227,7 +227,7 @@ Component "{{<hl>}}upload.example.org{{</hl>}}" "http_file_share"
 A big concern with file sharing is large files, seeing as all files shared over XMPP will be stored on your server. This can become a problem when many (and large) files are being shared. We can put a cap on large files by adding the following line to our config:
 
 ```lua
-http_file_share_file_size_limit = 20971520
+http_file_share_size_limit = 20971520
 ```
 
 This puts a 20MB cap on all files being shared. The value is specified in bytes. You can also specify after how long files should be deleted by adding the following line:


### PR DESCRIPTION
Hey, thanks for making the site. Lots of great and simple tutorials.

Just a tiny PR to correct a typo for `http_file_share_size_limit` as per [Prosody's docs](https://prosody.im/doc/modules/mod_http_file_share).