### PR TITLE
Fix author information link in footer

### DIFF
--- a/content/server/mumble.md
+++ b/content/server/mumble.md
@@ -7,7 +7,7 @@ icon: mumble.svg
 ports: [64738]
 
 ## Author Information
-author: denshi
+author: Denshi
 ---
 
 [Mumble](https://www.mumble.info/) is a light and high-quality libre voice chat protocol. You can self-host your own Mumble server and control your conversations.

--- a/content/server/tor-daemon.md
+++ b/content/server/tor-daemon.md
@@ -7,7 +7,7 @@ date: 2024-01-15T08:49:36-05:00
 ports: [9015, 9020]
 
 ## Author Information
-author: denshi
+author: Denshi
 draft: true
 ---
 


### PR DESCRIPTION
The link wasn't showing up because the D wasn't capitalized