### PR TITLE
fix: update mumble instructions for default user:group

### DIFF
--- a/content/server/mumble.md
+++ b/content/server/mumble.md
@@ -58,7 +58,7 @@ sslKey=/usr/share/certs/{{<hl>}}example.org{{</hl>}}/privkey.pem
 Make sure to give appropriate file permissions to `mumble-user`:
 
 ```sh
-chown -R mumble-user:mumble-user /usr/share/certs/{{<hl>}}example.org{{</hl>}}
+chown -R mumble-server:mumble-server /usr/share/certs/{{<hl>}}example.org{{</hl>}}
 ```
 
 ### Public Directory


### PR DESCRIPTION
On Debian 11, the resulting user/group name was, by default, `mumble-server:mumble-server`. I've proposed an update for the `chown -R` command to update this. I am not 100% if this is the case with current distributions.