### PR TITLE
fixed typo in prosody guide

### DIFF
--- a/content/server/prosody.md
+++ b/content/server/prosody.md
@@ -250,7 +250,7 @@ It's essential to obtain **any other certificates** for [additional services](#c
 
 ```sh
 certbot -d {{<hl>}}chat.example.org{{</hl>}} --nginx
-certbot -d {{<hl>}}uploads.example.org{{</hl>}} --nginx
+certbot -d {{<hl>}}upload.example.org{{</hl>}} --nginx
 certbot -d {{<hl>}}proxy.example.org{{</hl>}} --nginx
 certbot -d {{<hl>}}pubsub.example.org{{</hl>}} --nginx
 ```


### PR DESCRIPTION
I noticed that to enable file uploads, the guide tells you to add the following line to the prosody config:

```Component "upload.example.org" "http_file_share"```

But the guide later tells you to use this line to create certificates:

```certbot -d uploads.example.org --nginx```

in my PR I changed the line above to ```certbot -d upload.example.org --nginx``` so that the guide is more consistent 